### PR TITLE
Fix backup workflow bucket name issue

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -24,13 +24,13 @@ jobs:
 
           rm -r wp-content/cache
 
-          source app/.env
-
           docker run --rm \
             -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
             -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            -e BACKUP_BUCKET_NAME=${{ secrets.BACKUP_BUCKET_NAME }} \
             -v $(pwd):/backup amazon/aws-cli s3 cp /backup/backup.sql s3://$BACKUP_BUCKET_NAME/backup.sql
           docker run --rm \
             -e AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }} \
             -e AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
+            -e BACKUP_BUCKET_NAME=${{ secrets.BACKUP_BUCKET_NAME }} \
             -v $(pwd):/backup amazon/aws-cli s3 sync /backup/wp-content s3://$BACKUP_BUCKET_NAME/wp-content


### PR DESCRIPTION
## Summary
- Fixes backup workflow failure where BACKUP_BUCKET_NAME was empty
- Removes dependency on instance .env file for bucket name
- Uses GitHub secret directly following DevOps best practices

## Changes
- Remove `source app/.env` line from backup workflow
- Pass `BACKUP_BUCKET_NAME` directly from GitHub secrets to AWS CLI containers

## Test Plan
- [x] actionlint validation passed
- [ ] Test backup workflow manually after merge
- [ ] Verify S3 upload succeeds with bucket name `inma-infra-backup-3558082`

Fixes #42

🤖 Generated with [Claude Code](https://claude.ai/code)